### PR TITLE
Add command and workflow to validate rates.yaml

### DIFF
--- a/.github/workflows/validate-rates.yaml
+++ b/.github/workflows/validate-rates.yaml
@@ -1,0 +1,29 @@
+name: Validate rates file
+on:
+  push:
+    paths:
+      - rates.yaml
+  pull_request:
+    paths:
+      - rates.yaml
+
+jobs:
+  validate-rates-file:
+    name: Validate rates file
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          pip install -e .
+
+      - name: Validate rates file
+        run: |
+          validate-rates-file -g rates.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,10 @@ dependencies = [
   "requests",
 ]
 
+[project.entry-points."console_scripts"]
+validate-rates-file = "nerc_rates.cmd.validate_rates_file:main"
+
+
 [build-system]
 requires = [
   "setuptools>=42",

--- a/src/nerc_rates/cmd/validate_rates_file.py
+++ b/src/nerc_rates/cmd/validate_rates_file.py
@@ -1,0 +1,46 @@
+import sys
+import argparse
+import pydantic
+import yaml
+
+from .. import rates
+
+
+def pydantic_to_github(err, rates_file):
+    """Produce a github error annotation from a pydantic ValidationError"""
+    for error in err.errors():
+        print(f"::error file={rates_file},title=Validation error::{error['msg']}")
+
+
+def yaml_to_github(err, rates_file):
+    """Produce a github error annotation from a YAML ParserError"""
+    line = err.problem_mark.line
+    print(
+        f"::error file={rates_file},line={line},title=Parser error::{err.context}: {err.problem}"
+    )
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "-g", "--github", action="store_true", help="Emit github workflow annotations"
+    )
+    p.add_argument("-u", "--url", action="store_true", help="Rate file is a url")
+    p.add_argument("rates_file", default="rates.yaml", nargs="?")
+    args = p.parse_args()
+
+    try:
+        if args.url:
+            r = rates.load_from_url(args.rates_file)
+        else:
+            r = rates.load_from_file(args.rates_file)
+
+        print(f"OK [{len(r.root)} entries]")
+    except pydantic.ValidationError as err:
+        if args.github:
+            pydantic_to_github(err, args.rates_file)
+        sys.exit(err)
+    except yaml.parser.ParserError as err:
+        if args.github:
+            yaml_to_github(err, args.rates_file)
+        sys.exit(err)

--- a/src/nerc_rates/rates.py
+++ b/src/nerc_rates/rates.py
@@ -3,20 +3,26 @@ import yaml
 
 from .models import Rates
 
-DEFAULT_URL = "https://raw.githubusercontent.com/knikolla/nerc-rates/main/rates.yaml"
+DEFAULT_RATES_FILE = "rates.yaml"
+DEFAULT_RATES_URL = (
+    "https://raw.githubusercontent.com/CCI-MOC/nerc-rates/main/rates.yaml"
+)
 
 
-def load_from_url(url=DEFAULT_URL) -> Rates:
+def load_from_url(url: str | None = None) -> Rates:
+    if url is None:
+        url = DEFAULT_RATES_URL
+
     r = requests.get(url, allow_redirects=True)
-    # Using the BaseLoader prevents conversion of numeric
-    # values to floats and loads them as strings.
+    r.raise_for_status()
     config = yaml.safe_load(r.content.decode("utf-8"))
     return Rates.model_validate(config)
 
 
-def load_from_file() -> Rates:
-    with open("rates.yaml", "r") as f:
-        # Using the BaseLoader prevents conversion of numeric
-        # values to floats and loads them as strings.
+def load_from_file(path: str | None = None) -> Rates:
+    if path is None:
+        path = DEFAULT_RATES_FILE
+
+    with open(path, "r") as f:
         config = yaml.safe_load(f)
     return Rates.model_validate(config)

--- a/src/nerc_rates/tests/test_rates.py
+++ b/src/nerc_rates/tests/test_rates.py
@@ -12,7 +12,7 @@ def test_load_from_url():
           from: 2023-06
     """
     with requests_mock.Mocker() as m:
-        m.get(rates.DEFAULT_URL, text=mock_response_text)
+        m.get(rates.DEFAULT_RATES_URL, text=mock_response_text)
         r = load_from_url()
         assert r.get_value_at("CPU SU Rate", "2023-06") == "0.013"
 


### PR DESCRIPTION
We want to ensure that new changes do not introduce errors in rates.yaml.
This commit adds a `validate-rates-file` command and an associated Github
workflow that will use the new command to validate `rates.yaml` on pull
requests.

The validate-rates-file command knows how to generate github annotations [1]
for pydantic validation errors and yaml parse errors.

[1]: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
