### PR TITLE
Added new flag to limit New-PI credit to MGHPCC partners

### DIFF
--- a/rates.yaml
+++ b/rates.yaml
@@ -50,6 +50,14 @@
     - value: "True"
       from: 2024-03
 
+- name: Limit New PI Credit to MGHPCC Partners
+  history:
+  - value: "False"
+    from: 2023-06
+    until: 2024-08
+  - value: "True"
+    from: 2024-09
+
 #################################################
 # SU Definitions
 #################################################


### PR DESCRIPTION
As part of CCI-MOC/process_csv_report#94. I have added a flag to limit the new PI credit to MGHPCC partner institutions.
@joachimweyl I am assuming we are limiting the credit starting on October?