### PR TITLE
Added SU definition for all remaining SUs

### DIFF
--- a/rates.yaml
+++ b/rates.yaml
@@ -97,6 +97,87 @@
     - value: "4096"
       from: 2023-06
 
+- name: vGPUs in CPU SU
+  history:
+    - value: "0"
+      from: 2023-06
+
+- name: vCPUs in GPUA100 SU
+  history:
+    - value: "24"
+      from: 2023-06
+
+- name: RAM in GPUA100 SU
+  history:
+    - value: "75776"
+      from: 2023-06
+
+- name: vGPUs in GPUA100 SU
+  history:
+    - value: "1"
+      from: 2023-06
+
+- name: vCPUs in GPUA100SXM4 SU
+  history:
+    - value: "31"
+      from: 2023-06
+
+- name: RAM in GPUA100SXM4 SU
+  history:
+    - value: "245760"
+      from: 2023-06
+
+- name: vGPUs in GPUA100SXM4 SU
+  history:
+    - value: "1"
+      from: 2023-06
+
+- name: vCPUs in GPUV100 SU
+  history:
+    - value: "48"
+      from: 2023-06
+
+- name: RAM in GPUV100 SU
+  history:
+    - value: "196608"
+      from: 2023-06
+
+- name: vGPUs in GPUV100 SU
+  history:
+    - value: "1"
+      from: 2023-06
+
+- name: vCPUs in GPUK80 SU
+  history:
+    - value: "6"
+      from: 2023-06
+
+- name: RAM in GPUK80 SU
+  history:
+    - value: "29184"
+      from: 2023-06
+
+- name: vGPUs in GPUK80 SU
+  history:
+    - value: "1"
+      from: 2023-06
+
+- name: vCPUs in GPUH100 SU
+  history:
+    - value: "63"
+      from: 2023-06
+
+- name: RAM in GPUH100 SU
+  history:
+    - value: "385024"
+      from: 2023-06
+
+- name: vGPUs in GPUH100 SU
+  history:
+    - value: "1"
+      from: 2023-06
+
+
 #################################################
 # Invoicing Values
 #################################################


### PR DESCRIPTION
Closes #16. This is one of my two proposed solutions, where there is an entry for each SU/Resource combination.
The other solution is #17 

A sample code to fetch SU info with this format would look something like this:

```python
su_names = ["GPUK80", "GPUA100SXM4", "GPUH100", "CPU"]
resource_names = ["vCPUs", "RAM", "vGPUs"]
su_def_delimiter = ","
su_def_dict = {}

nerc_data = load_from_file()
for su_name in su_names:
    su_def_dict.setdefault(su_name, {})
    for resource_name in resource_names:
        su_def_dict[su_name][resource_name] = nerc_data.get_value_at(
            f"{resource_name} in {su_name} SU", "2024-12"
        )
```
