### PR TITLE
Added simple typing for rates with unit tests

### DIFF
--- a/src/nerc_rates/models.py
+++ b/src/nerc_rates/models.py
@@ -2,6 +2,7 @@
 from typing_extensions import Self
 from typing import Annotated
 
+from decimal import Decimal
 import datetime
 import pydantic
 
@@ -21,14 +22,17 @@ DateField = Annotated[datetime.date, pydantic.BeforeValidator(parse_date)]
 
 class RateValue(Base):
     value: str
+    type: str | None = None 
     date_from: Annotated[DateField, pydantic.Field(alias="from")]
     date_until: Annotated[DateField, pydantic.Field(alias="until", default=None)]
 
     @pydantic.model_validator(mode="after")
     @classmethod
-    def validate_date_range(cls, data: Self):
+    def validate_date_range_type(cls, data: Self):
         if data.date_until and data.date_until < data.date_from:
             raise ValueError("date_until must be after date_from")
+        if data.type and data.type not in {"str", "Decimal", "bool"}:
+            raise ValueError('type must be one of "str", "Decimal", or "bool"')
         return data
 
 
@@ -75,10 +79,30 @@ class Rates(pydantic.RootModel):
     def __getitem__(self, item):
         return self.root[item]
 
-    def get_value_at(self, name: str, queried_date: datetime.date | str):
+    def _get_rate_item(self, name: str, queried_date: datetime.date | str):
         d = parse_date(queried_date)
-        for item in self.root[name].history:
+        rate_item = self.root.get(name)
+        if not rate_item:
+            raise ValueError(f"Rate '{name}' not found")
+        for item in rate_item.history:
             if item.date_from <= d <= (item.date_until or d):
-                return item.value
-
-        raise ValueError(f"No value for {name} for {queried_date}.")
+                return item
+        raise ValueError(f"No value for '{name}' found for date '{queried_date}'.")
+    
+    def get_value_at(self, name: str, queried_date: datetime.date | str, datatype: type | None = None): 
+        rate_item = self._get_rate_item(name, queried_date)
+        if rate_item.type:
+            expected_type = {"str": str, "bool": bool, "Decimal": Decimal}.get(rate_item.type)
+            if not datatype:
+                return rate_item.value
+            if datatype != expected_type: 
+                raise TypeError(f'Rate "{name}" expects datatype {expected_type.__name__}, 'f'but got {datatype.__name__}.')
+            if expected_type == bool:
+                return rate_item.value.lower() in ("true", "1")
+            if expected_type == Decimal:
+                return Decimal(rate_item.value)
+            if expected_type == str:
+                return str(rate_item.value)
+        if datatype and not rate_item.type:
+            raise TypeError(f'Rate "{name}" does not define a type but you provided datatype={datatype.__name__}.')
+        return rate_item.value

--- a/src/nerc_rates/tests/test_rates.py
+++ b/src/nerc_rates/tests/test_rates.py
@@ -2,6 +2,7 @@ import pytest
 import pydantic
 import requests_mock
 
+from decimal import Decimal
 from nerc_rates import load_from_url, rates, models
 
 
@@ -109,3 +110,74 @@ def test_fail_with_duplicate_names():
                 },
             ]
         )
+
+
+@pytest.fixture
+def sample_rates():
+    return rates.Rates(
+        [
+            # Decimal-typed rate to test Decimal casting
+            {
+                "name": "Decimal Rate",
+                "history": [
+                    {"value": "1.23", "from": "2020-01", "type": "Decimal"},
+                ],
+            },
+            # Boolean-typed rate to test boolean parsing (string "true" -> True)
+            {
+                "name": "Boolean Rate",
+                "history": [
+                    {"value": "true", "from": "2020-01", "type": "bool"},
+                ],
+            },
+            # String-typed rate to test that it returns as string
+            {
+                "name": "String Rate",
+                "history": [
+                    {"value": "standard", "from": "2020-01", "type": "str"},
+                ],
+            },
+            # Legacy rate (no type) to test backward compatibility
+            {
+                "name": "Legacy Rate",
+                "history": [
+                    {"value": "legacy_value", "from": "2020-01"},
+                ],
+            },
+        ]
+    )
+
+
+def test_decimal_cast(sample_rates):
+    result = sample_rates.get_value_at("Decimal Rate", "2020-01", Decimal)
+    assert result == Decimal("1.23")
+
+
+def test_bool_cast(sample_rates):
+    result = sample_rates.get_value_at("Boolean Rate", "2020-01", bool)
+    assert result is True
+
+
+def test_string_cast(sample_rates):
+    result = sample_rates.get_value_at("String Rate", "2020-01", str)
+    assert result == "standard"
+
+
+def test_returns_raw_string_when_no_datatype(sample_rates):
+    result = sample_rates.get_value_at("Decimal Rate", "2020-01")
+    assert result == "1.23"
+
+
+def test_raises_if_wrong_datatype(sample_rates):
+    with pytest.raises(TypeError, match='expects datatype Decimal, but got bool'):
+        sample_rates.get_value_at("Decimal Rate", "2020-01", bool)
+
+
+def test_raises_if_datatype_given_but_no_type_defined(sample_rates):
+    with pytest.raises(TypeError, match='does not define a type but you provided datatype=Decimal'):
+        sample_rates.get_value_at("Legacy Rate", "2020-01", Decimal)
+
+
+def test_returns_raw_string_legacy_data(sample_rates):
+    result = sample_rates.get_value_at("Legacy Rate", "2020-01")
+    assert result == "legacy_value"


### PR DESCRIPTION
- Added support for optional datatype enforcement in get_value_at()
- Ensures correct casting to Decimal, bool, or str based on rate type
- Raises TypeError on mismatches or if datatype is provided without a defined type
- Includes unit tests for correct behavior, errors, and legacy support
