### PR TITLE
Upgrades python version in CI to 3.13

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -6,10 +6,13 @@ on:
 
 jobs:
   pre-commit:
+    strategy:
+      matrix:
+        python-version: [3.12, 3.13]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: ${{ matrix.python-version }}
     - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   run-unit-tests:
+    strategy:
+      matrix:
+        python-version: [3.12, 3.13]
     name: Run unit tests
     runs-on: ubuntu-latest
     steps:
@@ -14,7 +17,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/validate-rates.yaml
+++ b/.github/workflows/validate-rates.yaml
@@ -9,6 +9,9 @@ on:
 
 jobs:
   validate-rates-file:
+    strategy:
+      matrix:
+        python-version: [3.12, 3.13]
     name: Validate rates file
     runs-on: ubuntu-latest
     steps:
@@ -18,7 +21,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 classifiers = [
   "Programming Language :: Python :: 3"
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 dependencies = [
   "pydantic",
   "pyyaml",


### PR DESCRIPTION
I also bumped the minimum required Python version to 3.11 as that is the version that enum.StrEnum[1] was introduced. enum.StrEnum is a feature that will be used in #22.

[1] https://docs.python.org/3/library/enum.html#enum.StrEnum