### PR TITLE
Remove hardcoding, removal of duplicate unit test, remove extra Any import

### DIFF
--- a/src/nerc_rates/models.py
+++ b/src/nerc_rates/models.py
@@ -1,6 +1,6 @@
 # For python < 3.11, we need typing_extensions.Self instead of typing.Self
 from typing_extensions import Self
-from typing import Annotated, Any
+from typing import Annotated
 from enum import StrEnum
 from decimal import Decimal
 

--- a/src/nerc_rates/models.py
+++ b/src/nerc_rates/models.py
@@ -65,7 +65,7 @@ class RateItem(Base):
     @pydantic.model_validator(mode="after")
     @classmethod
     def validate_rate_type(cls, data: Self):
-        rate_type = {"str": str, "bool": bool, "Decimal": Decimal}.get(
+        rate_type = {RateType.STR: str, RateType.BOOL: bool, RateType.DECIMAL: Decimal}.get(
                     data.type)
         for x in data.history:
             if rate_type == Decimal:
@@ -112,7 +112,7 @@ class Rates(pydantic.RootModel):
         rate_item_obj = self.root.get(name)
         rate_value = self._get_rate_item(name, queried_date)
         if rate_item_obj.type is not None:
-            expected_type = {"str": str, "bool": bool, "Decimal": Decimal}.get(rate_item_obj.type)
+            expected_type = {RateType.STR: str, RateType.BOOL: bool, RateType.DECIMAL: Decimal}.get(rate_item_obj.type)
             if datatype and datatype != expected_type:
                 raise TypeError(
                     f'Rate {name} expects datatype {expected_type.__name__}, '

--- a/src/nerc_rates/tests/test_rates.py
+++ b/src/nerc_rates/tests/test_rates.py
@@ -41,18 +41,6 @@ def test_invalid_rate_type():
         models.RateItem.model_validate(rate)
 
 
-def test_invalid_rate_type():
-    rate = {"name": "Test Rate", "type": "invalid_type",
-            "history": [
-            {"value": "1", "from": "2020-01"},
-        ],
-    }
-    with pytest.raises(
-        pydantic.ValidationError, match="Input should be 'str', 'Decimal' or 'bool'"
-    ):
-        models.RateItem.model_validate(rate)
-
-
 def test_missing_type_field():
     rate = {
         "name": "Test Rate Missing Type",


### PR DESCRIPTION
Removed hardcoding of enum as suggested in models.py, removed duplicate test_invalid_rate_type unit test in tests.py, remove extra Any import. 