### PR TITLE
Switch to Ruff linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,9 @@
 repos:
-  - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.5
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.10
     hooks:
-      - id: remove-tabs
+      - id: ruff
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/src/nerc_rates/__init__.py
+++ b/src/nerc_rates/__init__.py
@@ -1,1 +1,0 @@
-from nerc_rates.rates import load_from_file, load_from_url

--- a/src/nerc_rates/models.py
+++ b/src/nerc_rates/models.py
@@ -65,17 +65,22 @@ class RateItem(Base):
     @pydantic.model_validator(mode="after")
     @classmethod
     def validate_rate_type(cls, data: Self):
-        rate_type = {RateType.STR: str, RateType.BOOL: bool, RateType.DECIMAL: Decimal}.get(
-                    data.type)
+        rate_type = {
+            RateType.STR: str,
+            RateType.BOOL: bool,
+            RateType.DECIMAL: Decimal,
+        }.get(data.type)
         for x in data.history:
             if rate_type == Decimal:
                 try:
                     Decimal(x.value)
                 except Exception:
                     raise ValueError(f"{x} is not valid Decimal")
-            elif rate_type == bool:
+            elif rate_type is bool:
                 if x.value.lower() not in ["true", "false"]:
-                    raise ValueError(f"Bool field must be a string of either True or False, got {x.value}")
+                    raise ValueError(
+                        f"Bool field must be a string of either True or False, got {x.value}"
+                    )
         return data
 
 
@@ -83,7 +88,7 @@ def check_for_duplicates(items):
     data = {}
     for item in items:
         if item["name"] in data:
-            raise ValueError(f"found duplicate name \"{item['name']}\" in list")
+            raise ValueError(f'found duplicate name "{item["name"]}" in list')
         data[item["name"]] = item
     return data
 
@@ -108,15 +113,21 @@ class Rates(pydantic.RootModel):
 
         raise ValueError(f"No value for {name} for {queried_date}.")
 
-    def get_value_at(self, name: str, queried_date: datetime.date | str, datatype: type | None = None):
+    def get_value_at(
+        self, name: str, queried_date: datetime.date | str, datatype: type | None = None
+    ):
         rate_item_obj = self.root.get(name)
         rate_value = self._get_rate_item(name, queried_date)
         if rate_item_obj.type is not None:
-            expected_type = {RateType.STR: str, RateType.BOOL: bool, RateType.DECIMAL: Decimal}.get(rate_item_obj.type)
+            expected_type = {
+                RateType.STR: str,
+                RateType.BOOL: bool,
+                RateType.DECIMAL: Decimal,
+            }.get(rate_item_obj.type)
             if datatype and datatype != expected_type:
                 raise TypeError(
-                    f'Rate {name} expects datatype {expected_type.__name__}, '
-                    f'but got {datatype.__name__}.'
+                    f"Rate {name} expects datatype {expected_type.__name__}, "
+                    f"but got {datatype.__name__}."
                 )
             if expected_type is bool:
                 return rate_value.value.lower() in ("true", "1")

--- a/src/nerc_rates/tests/test_rates.py
+++ b/src/nerc_rates/tests/test_rates.py
@@ -4,7 +4,8 @@ import pytest
 import pydantic
 import requests_mock
 
-from nerc_rates import load_from_url, rates, models
+from nerc_rates import rates, models
+from nerc_rates.rates import load_from_url
 
 
 def test_load_from_url():
@@ -29,9 +30,11 @@ def test_invalid_date_order():
         models.RateValue.model_validate(rate)
 
 
-def test_invalid_rate_type():
-    rate = {"name": "Test Rate", "type": "invalid_type",
-            "history": [
+def test_invalid_input_type():
+    rate = {
+        "name": "Test Rate",
+        "type": "invalid_type",
+        "history": [
             {"value": "1", "from": "2020-01"},
         ],
     }
@@ -48,9 +51,7 @@ def test_missing_type_field():
             {"value": "1.23", "from": "2023-01"},
         ],
     }
-    with pytest.raises(
-        pydantic.ValidationError, match="type\n  Field required"
-    ):
+    with pytest.raises(pydantic.ValidationError, match="type\n  Field required"):
         models.RateItem.model_validate(rate)
 
 
@@ -120,7 +121,10 @@ def test_invalid_date_overlap(rate):
     ],
 )
 def test_invalid_rate_type(rate_item_data):
-    with pytest.raises(pydantic.ValidationError, match="Bool field must be a string of either True or False|is not valid Decimal"):
+    with pytest.raises(
+        pydantic.ValidationError,
+        match="Bool field must be a string of either True or False|is not valid Decimal",
+    ):
         models.RateItem.model_validate(rate_item_data)
 
 
@@ -209,8 +213,6 @@ def sample_rates():
         ("Boolean Rate", "2020-01", Decimal, None, TypeError),
     ],
 )
-
-
 def test_get_value_at_cases(sample_rates, name, query_date, datatype, expected, raises):
     if raises:
         with pytest.raises(raises):


### PR DESCRIPTION
Switching to Ruff allows us to conform with the rest of the repositories that currently use Ruff. More features from Ruff will allow us to practice better code hygiene for this repository.