### PR TITLE
Update rates.yaml

### DIFF
--- a/rates.yaml
+++ b/rates.yaml
@@ -277,7 +277,7 @@
 - name: vCPUs in BM GPUH100 SU
   type: "Decimal"
   history:
-    - value: "256"
+    - value: "512"
       from: 2023-06
 
 - name: RAM in BM GPUH100 SU


### PR DESCRIPTION
BM should be all the vCPUs, there are 2 EPYC 9754 which have 256 each so that is 512. This will not change anything in our Invoice calculations but it will change the Pricing for Bare Metal Machines on NERC table.