### PR TITLE
Remove Storage GB Rate

### DIFF
--- a/rates.yaml
+++ b/rates.yaml
@@ -37,15 +37,6 @@
     - value: "0.463"
       from: 2023-06
 
-- name: Storage GB Rate
-  type: "Decimal"
-  history:
-    - value: "0.000009"
-      from: 2023-06
-      until: 2024-05
-    - value: "0.0000087890625"
-      from: 2024-06
-
 - name: NESE Storage GB Rate
   type: "Decimal"
   history:


### PR DESCRIPTION
Closes #45. Brought up in https://github.com/CCI-MOC/nerc-rates/issues/45#issuecomment-3233591450. Storage GB Rate no longer needed as repos have been updated with NESE Storage GB Rate.