### PR TITLE
Added dynamic H100 Lenovo charges for 2026 and 2027

### DIFF
--- a/rates.yaml
+++ b/rates.yaml
@@ -328,3 +328,9 @@
   history:
     - value: "2.74"
       from: 2025-06
+      until: 2026-05
+    - value: "2.49"
+      from: 2026-06
+      until: 2027-05
+    - value: "2.24"
+      from: 2027-06


### PR DESCRIPTION
Partially closes #40. My idea is that invoicing scripts will further increase the charge depending on utilization.